### PR TITLE
(TASK-65) DeveloperExceptionHandlerMiddleware throws an Exception

### DIFF
--- a/WebAPI/Middlewares/DeveloperExceptionHandlerMiddleware.cs
+++ b/WebAPI/Middlewares/DeveloperExceptionHandlerMiddleware.cs
@@ -19,7 +19,7 @@ public class DeveloperExceptionHandlerMiddleware : IMiddleware
                     Status = StatusCodes.Status500InternalServerError,
                     Type = "https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.1",
                     Title = e.Message,
-                    Detail = e.InnerException!.Message + Environment.NewLine + e.StackTrace,
+                    Detail = e.InnerException?.Message + Environment.NewLine + e?.StackTrace,
                 },
                 context
             );


### PR DESCRIPTION
Keep in mind you can change behavior (response) for production and development environments in launchSettings.json by setting `"ASPNETCORE_ENVIRONMENT": "Production"`